### PR TITLE
Updates to README and docker-compose.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A dockerized web service for creating PDFs from HTML using WeasyPrint
 
 ## Description
 
-[WeasyPrint](https://weasyprint.readthedocs.io/en/stable/index.html)
+[WeasyPrint](https://weasyprint.org)
 is a visual rendering engine for HTML and CSS that can export to PDF.
 It aims to support web standards for printing.
 
@@ -17,7 +17,7 @@ The web service is written in Python using the aiohttp web server.
 
 To start the webservice just run
 ```
-docker-compose up
+docker compose up
 ```
 
 The html file and and any additional files must be uploaded as multipart/form-data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   weasyprint:
     build:


### PR DESCRIPTION
- updated broken link in README
- updated docker compose command
- removed version from docker-compose.yml to fix warning - `version` is obsolete