### PR TITLE
Allow to pass options

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,16 @@ Example:
 curl -F "html=@tests/index.html" -F "asset.universe.jpg=@tests/universe.jpg" http://localhost:3000 -o test.pdf
 ```
 
+### Options
+
+It's possible to overwrite some [weasyprint.DEFAULT_OPTIONS](https://doc.courtbouillon.org/weasyprint/stable/api_reference.html#weasyprint.DEFAULT_OPTIONS) by passing the option prefixed with `option.` as part of the form-request.
+
+Example:
+
+```
+curl -F "option.pdf_variant=pdf/a-3b" -F "html=@tests/index.html" http://localhost:3000 -o test.pdf
+```
+
 ### Configuration
 
 By default fetching external resource is prohibited for security reasons.


### PR DESCRIPTION
Hi @buchi 

We are investigating the possibility to create PDF/A-compliant files. This should be possible with some additional options (see [init.py::63](https://github.com/Kozea/WeasyPrint/blob/4d2f93238cf70eadbc3321d8eafe7ee17aa1edd1/weasyprint/__init__.py#L63)), the most important one obviously the `pdf_variant`-option.

This is a simple suggestion how to enable the client to configure the options. This implementation assumes, that the client can be trusted, as there is no protection in place (although, with the available options I don't see to much danger here. Maybe the `cache`-option should be removed from the API, but the others seem save).
